### PR TITLE
Fix NaN float error

### DIFF
--- a/msa_exporter.py
+++ b/msa_exporter.py
@@ -836,6 +836,7 @@ def scrap_msa(metrics_store, host, login, password):
                           if elem.get('name') in source.get('properties_as_label', {})}
                 labels.update(source.get('labels', {}))
                 value = obj.find(source['property_selector']).text
+                if value == 'N/A' : value = 'nan'
                 metrics_store.get_or_create(metric.get('type', 'gauge'), name, metric['description'], labels).set(value)
 
 


### PR DESCRIPTION
Fix the following exception:
Traceback (most recent call last):
  File "./msa_exporter.py", line 855, in <module>
    scrap_msa(metrics_store, args.hostname, args.login, args.password)
  File "./msa_exporter.py", line 839, in scrap_msa
    metrics_store.get_or_create(metric.get('type', 'gauge'), name, metric['description'], labels).set(value)
  File "/usr/local/lib/python3.6/site-packages/prometheus_client/core.py", line 678, in set
    self._value.set(float(value))
ValueError: could not convert string to float: 'N/A'